### PR TITLE
Define Error#getMessage = toString

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/Error.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/Error.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 
 sealed trait Error extends Exception {
   final override def fillInStackTrace(): Throwable = this
+  final override def getMessage: String = toString
 }
 object Error {
   final case class ParseFailure(reason: String) extends Error


### PR DESCRIPTION
Currently `getMessage` returns `null`, which is surprising and can break things. Since the errors define reasonable `toStrings`, use those as the message.