### PR TITLE
Add `PutOps` with `field` method

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/implicits/package.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/implicits/package.scala
@@ -8,3 +8,4 @@ package object implicits
     with syntax.labelledwrite
     with syntax.read
     with syntax.labelledread
+    with syntax.put

--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/syntax/put.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/syntax/put.scala
@@ -1,0 +1,11 @@
+package io.chrisdavenport.cormorant.syntax
+
+import io.chrisdavenport.cormorant.{CSV, Put}
+
+trait put {
+  implicit class putOps[A: Put](a: A) {
+    def field: CSV.Field = Put[A].put(a)
+  }
+}
+
+object put extends put


### PR DESCRIPTION
Useful method when creating a `Write` instance manually:

```scala
NonEmptyList.of(
   user.firstName.field,
   user.lastName.field,
   user.email.field
)
```

instead of:

```scala
NonEmptyList.of(
   Put[String].put(user.firstName),
   Put[String].put(user.lastName),
   Put[Option[String]].put(user.email)
)
```
