### PR TITLE
Fix error in fs2 write pipes

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/Printer.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/Printer.scala
@@ -4,6 +4,7 @@ import cats.implicits._
 
 trait Printer {
   def print(csv: CSV): String
+  val rowSeparator: String
 }
 
 object Printer {
@@ -31,7 +32,8 @@ object Printer {
       surround: String,
       additionalEscapes: Set[String] = Set.empty[String]): Printer =
     new Printer {
-      def print(csv: CSV): String = csv match {
+
+      override def print(csv: CSV): String = csv match {
         case CSV.Field(text) =>
           escapedAsNecessary(text, Set(columnSeperator, rowSeperator, escape, surround) ++ additionalEscapes, escape, surround)
         case CSV.Header(text) =>
@@ -41,6 +43,9 @@ object Printer {
         case CSV.Rows(xs) => xs.map(print).intercalate(rowSeperator)
         case CSV.Complete(headers, body) => print(headers) + rowSeperator + print(body)
       }
+
+      override val rowSeparator: String = rowSeperator
+
     }
 
   def default: Printer = generic(",", "\n", "\"", "\"", Set("\r"))

--- a/modules/fs2/src/main/scala/io/chrisdavenport/cormorant/fs2/package.scala
+++ b/modules/fs2/src/main/scala/io/chrisdavenport/cormorant/fs2/package.scala
@@ -61,11 +61,9 @@ package object fs2 {
     _.map(Write[A].write).through(encodeRows(p))
 
   def writeWithHeaders[F[_], A: Write](headers: CSV.Headers, p: Printer): Pipe[F, A, String] = s =>
-    Stream(p.print(headers)).covary[F] ++
-    s.through(writeRows(p))
+    Stream(p.print(headers)).covary[F] ++ s.through(writeRows(p))
 
   def writeLabelled[F[_], A: LabelledWrite](p: Printer): Pipe[F, A, String] = s =>
-    Stream(p.print(LabelledWrite[A].headers)).covary[F] ++
-    s.map(LabelledWrite[A].write).through(encodeRows(p))
+    s.through(writeWithHeaders(LabelledWrite[A].headers, p)(LabelledWrite[A].write))
 
 }

--- a/modules/fs2/src/main/scala/io/chrisdavenport/cormorant/fs2/package.scala
+++ b/modules/fs2/src/main/scala/io/chrisdavenport/cormorant/fs2/package.scala
@@ -101,6 +101,8 @@ package object fs2 {
     * }}}
     */
   def writeLabelled[F[_], A: LabelledWrite](p: Printer): Pipe[F, A, String] = s =>
-    s.through(writeWithHeaders(LabelledWrite[A].headers, p)(LabelledWrite[A].write))
+    s.through(writeWithHeaders(LabelledWrite[A].headers, p)(new Write[A] {
+      override def write(a: A): CSV.Row = LabelledWrite[A].write(a)
+    }))
 
 }

--- a/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingParseSpec.scala
+++ b/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingParseSpec.scala
@@ -1,31 +1,69 @@
 package io.chrisdavenport.cormorant.fs2
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import fs2.Stream
 import io.chrisdavenport.cormorant._
+import io.chrisdavenport.cormorant.implicits._
 
 class StreamingParseSpec extends CormorantSpec {
 
-    "Streaming printer should" in {
-      "row should round trip" in prop { a : CSV.Row => 
-        Stream.emit[IO, CSV.Row](a)
-          .through(encodeRows(Printer.default))
-          .through(parseRows)
-          .compile
-          .toList
-          .unsafeRunSync must_=== List(a)
-      }.set(minTestsOk = 20, workers = 2)
-    "rows should round trip" in prop { a: CSV.Rows => 
-      val decoded = CSV.Rows(
-        Stream.emits[IO, CSV.Row](a.rows)
+  "Streaming printer should" in {
+
+    "row should round trip" in prop { a: CSV.Row =>
+      Stream
+        .emit[IO, CSV.Row](a)
         .through(encodeRows(Printer.default))
         .through(parseRows)
         .compile
         .toList
-        .unsafeRunSync
+        .unsafeRunSync must_=== List(a)
+    }.set(minTestsOk = 20, workers = 2)
+
+    "rows should round trip" in prop { a: CSV.Rows =>
+      val decoded = CSV.Rows(
+        Stream
+          .emits[IO, CSV.Row](a.rows)
+          .through(encodeRows(Printer.default))
+          .through(parseRows)
+          .compile
+          .toList
+          .unsafeRunSync
       )
       decoded must_=== a
     }.set(minTestsOk = 20, workers = 2)
+
+    "complete should round trip " in {
+      case class Foo(color: String, food: String, number: Int)
+
+      val list = List(
+        Foo("Blue", "Pizza", 1),
+        Foo("Red", "Margarine", 2),
+        Foo("Yellow", "Broccoli", 3)
+      )
+
+      implicit val L: LabelledWrite[Foo] = new LabelledWrite[Foo] {
+        override def headers: CSV.Headers = CSV.Headers(
+          NonEmptyList.of(CSV.Header("Color"), CSV.Header("Food"), CSV.Header("Number"))
+        )
+
+        override def write(a: Foo): CSV.Row = CSV.Row(
+          NonEmptyList.of(a.color.field, a.food.field, a.number.field)
+        )
+      }
+
+      val result = Stream.emits(list)
+        .through(writeLabelled(Printer.default))
+        .compile
+        .string
+
+      val expectedCSVString = """Color,Food,Number
+                                |Blue,Pizza,1
+                                |Red,Margarine,2
+                                |Yellow,Broccoli,3""".stripMargin
+
+      result should_=== expectedCSVString
+    }
 
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
# What is the purpose of this PR?

Cormorant's fs2 write pipes don't add row separator. This PR fixes the issue by intercalating each row with the printer's row separator.

# What has been done in this PR?

- Expose `Printer`'s row separator as a new field in `Printer`'s trait
- Fix the issue by adding a stream containing the separator between headers-rows and in-between rows.
- Add some docs for `fs2` write pipes.
