### PR TITLE
Improve field usability

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/syntax/put.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/syntax/put.scala
@@ -3,9 +3,13 @@ package io.chrisdavenport.cormorant.syntax
 import io.chrisdavenport.cormorant.{CSV, Put}
 
 trait put {
-  implicit class putOps[A: Put](a: A) {
-    def field: CSV.Field = Put[A].put(a)
+
+  implicit class putOps[A](a: A) {
+
+    def field(implicit P: Put[A]): CSV.Field = P.put(a)
+
   }
+
 }
 
 object put extends put

--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/syntax/put.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/syntax/put.scala
@@ -6,6 +6,18 @@ trait put {
 
   implicit class putOps[A](a: A) {
 
+    /**
+      * Facilitates the transformation of any `A` with a `Put`
+      * instance into a field
+      *
+      * @example {{{
+      * //Before
+      * Put[String].put("hello")
+      *
+      * //After
+      * "Hello".field
+      * }}}
+      */
     def field(implicit P: Put[A]): CSV.Field = P.put(a)
 
   }


### PR DESCRIPTION
# What has been done in this PR?

Move the implicit in `field` method from the class to the method.

# Why?

On a missing implicit the error is different, as well as the help provided by the IDEs.

- Before (implicit in class)

![implicit-in-class](https://user-images.githubusercontent.com/9027541/62639992-e440ac80-b940-11e9-8e6b-1ae3c9541a89.png)

- After (implicit in method)

![implicit-in-def](https://user-images.githubusercontent.com/9027541/62639988-e30f7f80-b940-11e9-9dc9-ae890f234c6f.png)
