### PR TITLE
Fix Stackoverlow caused by getMessage

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/cormorant/Error.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cormorant/Error.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 sealed trait Error extends Exception {
   final override def fillInStackTrace(): Throwable = this
   final override def getMessage: String = toString
+  def toString: String
 }
 object Error {
   final case class ParseFailure(reason: String) extends Error
@@ -16,9 +17,7 @@ object Error {
       ParseFailure(s"Invalid Input: Received $input")
   }
 
-  final case class DecodeFailure(failure: NonEmptyList[String]) extends Error {
-    override def toString: String = s"DecodeFailure($failure)"
-  }
+  final case class DecodeFailure(failure: NonEmptyList[String]) extends Error
   object DecodeFailure {
     def single(reason: String): DecodeFailure = DecodeFailure(NonEmptyList.of(reason))
     implicit val decodeFailureSemigroup: Semigroup[DecodeFailure] = {
@@ -30,5 +29,4 @@ object Error {
   }
 
   final case class PrintFailure(reason: String) extends Error
-
 }


### PR DESCRIPTION
This PR aims to fix bug #93 which was caused by `getMesssage` being redefined to use the inherited `toString` which calls `getLocalizedMessage` which calss `getMessage`. This cycle of function calls resulted in a Stackoverflow error.

By declaring `toString` to be an abstract method of `Error` we impose to all its subclasses to override it. As all its subclasses are `case classes` which have a built in implementation of `toString` this fix is, in my opinion, the least intrusive solution to the problem.

The `toString` implementation of `DecodeFailure` was removed because it behaves exactly like the `toString` method built in in all case classes