### PR TITLE
Fix streaming parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val cormorant = project.in(file("."))
 
 val catsV = "2.0.0"
 val catsEffectV = "2.0.0"
+val catsEffectTestV = "0.3.0"
 val shapelessV = "2.3.3"
 val http4sV = "0.21.0-M6"
 val specs2V = "4.8.1"
@@ -70,7 +71,9 @@ lazy val fs2 = project.in(file("modules/fs2"))
   .settings(
     name := "cormorant-fs2",
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "2.1.0"
+      "co.fs2" %% "fs2-core" % "2.1.0",
+      "co.fs2" %% "fs2-io"   % "2.1.0" % Test,
+      "com.codecommit" %% "cats-effect-testing-specs2" % catsEffectTestV % Test
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ val catsEffectV = "2.0.0"
 val catsEffectTestV = "0.3.0"
 val shapelessV = "2.3.3"
 val http4sV = "0.21.0-M6"
+val catsScalacheckV = "0.2.0"
 val specs2V = "4.8.1"
 
 lazy val core = project.in(file("modules/core"))
@@ -160,6 +161,6 @@ lazy val commonSettings = Seq(
     "org.typelevel"               %% "cats-effect"                % catsEffectV,
     "org.specs2"                  %% "specs2-core"                % specs2V       % Test,
     "org.specs2"                  %% "specs2-scalacheck"          % specs2V       % Test,
-    "io.chrisdavenport"           %% "cats-scalacheck"            % "0.2.0"    % Test,
+    "io.chrisdavenport"           %% "cats-scalacheck"            % catsScalacheckV % Test,
   )
 )

--- a/modules/core/src/test/scala/io/chrisdavenport/cormorant/CormorantArbitraries.scala
+++ b/modules/core/src/test/scala/io/chrisdavenport/cormorant/CormorantArbitraries.scala
@@ -4,9 +4,15 @@ import org.scalacheck._
 import _root_.cats.data._
 
 trait CormorantArbitraries {
+    // Necessary for Round-tripping for fs2. As we can't always clarify the empty string following
+    // semantics. We use printable to remove the subset that doesn't pass through utf8 encoding
     implicit val arbField : Arbitrary[CSV.Field] = Arbitrary(
-    Gen.listOf(Gen.alphaNumStr).map(_.mkString).map(CSV.Field.apply)
-  )
+      for {
+        char <- Gen.asciiPrintableChar
+        string  <- Gen.asciiPrintableStr
+      } yield  CSV.Field(char.toString() + string)
+    )
+
 
   // Must be 1 or More
   def genRow(s: Int): Gen[CSV.Row] = for {
@@ -16,7 +22,7 @@ trait CormorantArbitraries {
 
   implicit val arbRow: Arbitrary[CSV.Row] = Arbitrary(
     for {
-      size <- Gen.choose(1, 100)
+      size <- Gen.choose(1, 25)
       row <- genRow(size)
     } yield row
   )
@@ -29,7 +35,7 @@ trait CormorantArbitraries {
 
   implicit val arbRows : Arbitrary[CSV.Rows] = Arbitrary(
     for {
-      choose <- Gen.choose(1, 100)
+      choose <- Gen.choose(1, 25)
       rows <- genRows(choose)
     } yield rows
   )
@@ -46,14 +52,14 @@ trait CormorantArbitraries {
 
   implicit val arbHeaders : Arbitrary[CSV.Headers] = Arbitrary(
     for {
-      choose <- Gen.choose(1, 100)
+      choose <- Gen.choose(1, 25)
       headers <- genHeaders(choose)
     } yield headers
   )
 
   implicit val arbComplete : Arbitrary[CSV.Complete] = Arbitrary(
     for {
-      choose <- Gen.choose(1, 100)
+      choose <- Gen.choose(1, 25)
       headers <- genHeaders(choose)
       rows <- genRows(choose)
     } yield CSV.Complete(headers, rows)

--- a/modules/core/src/test/scala/io/chrisdavenport/cormorant/CormorantArbitraries.scala
+++ b/modules/core/src/test/scala/io/chrisdavenport/cormorant/CormorantArbitraries.scala
@@ -5,7 +5,7 @@ import _root_.cats.data._
 
 trait CormorantArbitraries {
     implicit val arbField : Arbitrary[CSV.Field] = Arbitrary(
-    Gen.listOf(Arbitrary.arbitrary[String]).map(_.mkString).map(CSV.Field.apply)
+    Gen.listOf(Gen.alphaNumStr).map(_.mkString).map(CSV.Field.apply)
   )
 
   // Must be 1 or More
@@ -35,7 +35,7 @@ trait CormorantArbitraries {
   )
 
   implicit val arbHeader : Arbitrary[CSV.Header] = Arbitrary(
-    Gen.listOf(Arbitrary.arbitrary[String]).map(_.mkString).map(CSV.Header.apply)
+    Gen.listOf(Gen.alphaNumStr).map(_.mkString).map(CSV.Header.apply)
   )
 
   // Must be 1 or more

--- a/modules/core/src/test/scala/io/chrisdavenport/cormorant/CormorantArbitraries.scala
+++ b/modules/core/src/test/scala/io/chrisdavenport/cormorant/CormorantArbitraries.scala
@@ -40,8 +40,12 @@ trait CormorantArbitraries {
     } yield rows
   )
 
+  // Same logic as fields
   implicit val arbHeader : Arbitrary[CSV.Header] = Arbitrary(
-    Gen.listOf(Gen.alphaNumStr).map(_.mkString).map(CSV.Header.apply)
+    for {
+      char <- Gen.asciiPrintableChar
+      string  <- Gen.asciiPrintableStr
+    } yield  CSV.Header(char.toString() + string)
   )
 
   // Must be 1 or more

--- a/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingParserSpec.scala
+++ b/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingParserSpec.scala
@@ -1,0 +1,48 @@
+package io.chrisdavenport.cormorant
+package fs2
+
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.effect.specs2.CatsIO
+import _root_.fs2.Stream
+import io.chrisdavenport.cormorant._
+// import io.chrisdavenport.cormorant.implicits._
+// import scala.concurrent.duration._
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+class StreamingParserSpec extends CormorantSpec with CatsIO {
+
+  "Streaming Parser" should {
+    // https://github.com/ChristopherDavenport/cormorant/pull/84
+    "parse a known value that did not work with streaming" in {
+      val x = """First Name,Last Name,Email
+Larry,Bordowitz,larry@example.com
+Anonymous,Hippopotamus,hippo@example.com"""
+      val source = IO.pure(new ByteArrayInputStream(x.getBytes): InputStream)
+      Stream.resource(Blocker[IO]).flatMap{blocker => 
+        _root_.fs2.io.readInputStream(
+          source,
+          chunkSize = 4,
+          blocker
+        )
+      }
+        .through(_root_.fs2.text.utf8Decode)
+        .through(parseComplete[IO])
+        .compile
+        .toVector
+        .map{ v => 
+          val header = CSV.Headers(NonEmptyList.of(CSV.Header("First Name"), CSV.Header("Last Name"), CSV.Header("Email")))
+          val row1 = CSV.Row(NonEmptyList.of(CSV.Field("Larry"), CSV.Field("Bordowitz"), CSV.Field("larry@example.com")))
+          val row2 = CSV.Row(NonEmptyList.of(CSV.Field("Anonymous"), CSV.Field("Hippopotamus"), CSV.Field("hippo@example.com")))
+          Vector(
+            (header, row1),
+            (header, row2)
+          ) must_=== v
+        }
+    }
+  }
+
+  
+
+}

--- a/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingParserSpec.scala
+++ b/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingParserSpec.scala
@@ -13,13 +13,18 @@ import java.io.InputStream
 
 class StreamingParserSpec extends CormorantSpec with CatsIO {
 
+  def ruinDelims(str: String) = augmentString(str).flatMap {
+    case '\n' => "\r\n"
+    case c => c.toString
+  }
+
   "Streaming Parser" should {
     // https://github.com/ChristopherDavenport/cormorant/pull/84
     "parse a known value that did not work with streaming" in {
       val x = """First Name,Last Name,Email
 Larry,Bordowitz,larry@example.com
 Anonymous,Hippopotamus,hippo@example.com"""
-      val source = IO.pure(new ByteArrayInputStream(x.getBytes): InputStream)
+      val source = IO.pure(new ByteArrayInputStream(ruinDelims(x).getBytes): InputStream)
       Stream.resource(Blocker[IO]).flatMap{blocker => 
         _root_.fs2.io.readInputStream(
           source,

--- a/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingPrinterSpec.scala
+++ b/modules/fs2/src/test/scala/io/chrisdavenport/cormorant/fs2/StreamingPrinterSpec.scala
@@ -1,12 +1,17 @@
-package io.chrisdavenport.cormorant.fs2
+package io.chrisdavenport.cormorant
+package fs2
 
 import cats.data.NonEmptyList
-import cats.effect.IO
-import fs2.Stream
+import cats.effect._
+import cats.effect.specs2.CatsIO
+import _root_.fs2.Stream
 import io.chrisdavenport.cormorant._
 import io.chrisdavenport.cormorant.implicits._
+import scala.concurrent.duration._
 
-class StreamingParseSpec extends CormorantSpec {
+class StreamingPrinterSpec extends CormorantSpec with CatsIO {
+
+  override val Timeout = 1.minute
 
   "Streaming printer should" in {
 
@@ -34,7 +39,7 @@ class StreamingParseSpec extends CormorantSpec {
     }.set(minTestsOk = 20, workers = 2)
 
     "complete should round trip " in {
-      case class Foo(color: String, food: String, number: Int)
+      final case class Foo(color: String, food: String, number: Int)
 
       val list = List(
         Foo("Blue", "Pizza", 1),
@@ -64,6 +69,8 @@ class StreamingParseSpec extends CormorantSpec {
 
       result should_=== expectedCSVString
     }
+
+    
 
   }
 


### PR DESCRIPTION
- Fixes Cases of Streaming Parsers only reading fist line
- Had problem where last CRLF was being included in record, in order to make useable have opted to automatically clean, will switch to a flag next release.